### PR TITLE
Fix hex string handling

### DIFF
--- a/client/http_client.go
+++ b/client/http_client.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 
 	. "github.com/tendermint/go-common"
@@ -119,7 +121,7 @@ func (c *ClientURI) call(method string, params map[string]interface{}, result in
 	if err != nil {
 		return nil, err
 	}
-	//log.Info(Fmt("URI request to %v (%v): %v", c.address, method, values))
+	log.Info(Fmt("URI request to %v (%v): %v", c.address, method, values))
 	resp, err := c.client.PostForm(c.address+"/"+method, values)
 	if err != nil {
 		return nil, err
@@ -176,6 +178,21 @@ func argsToJson(args map[string]interface{}) error {
 	var n int
 	var err error
 	for k, v := range args {
+		// Convert strings to "0x"-prefixed hex
+		str, isString := reflect.ValueOf(v).Interface().(string)
+		if isString {
+			args[k] = fmt.Sprintf("0x%X", str)
+			continue
+		}
+
+		// Convert byte slices to "0x"-prefixed hex
+		byteSlice, isByteSlice := reflect.ValueOf(v).Interface().([]byte)
+		if isByteSlice {
+			args[k] = fmt.Sprintf("0x%X", byteSlice)
+			continue
+		}
+
+		// Pass everything else to go-wire
 		buf := new(bytes.Buffer)
 		wire.WriteJSON(v, buf, &n, &err)
 		if err != nil {

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -121,7 +121,7 @@ func (c *ClientURI) call(method string, params map[string]interface{}, result in
 	if err != nil {
 		return nil, err
 	}
-	log.Info(Fmt("URI request to %v (%v): %v", c.address, method, values))
+	// log.Info(Fmt("URI request to %v (%v): %v", c.address, method, values))
 	resp, err := c.client.PostForm(c.address+"/"+method, values)
 	if err != nil {
 		return nil, err
@@ -178,13 +178,6 @@ func argsToJson(args map[string]interface{}) error {
 	var n int
 	var err error
 	for k, v := range args {
-		// Convert strings to "0x"-prefixed hex
-		str, isString := reflect.ValueOf(v).Interface().(string)
-		if isString {
-			args[k] = fmt.Sprintf("0x%X", str)
-			continue
-		}
-
 		// Convert byte slices to "0x"-prefixed hex
 		byteSlice, isByteSlice := reflect.ValueOf(v).Interface().([]byte)
 		if isByteSlice {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -164,3 +164,39 @@ func TestWS_UNIX(t *testing.T) {
 	}
 	testWS(t, cl)
 }
+
+func TestHexStringArg(t *testing.T) {
+	cl := rpcclient.NewClientURI(tcpAddr)
+	// should NOT be handled as hex
+	val := "0xabc"
+	params := map[string]interface{}{
+		"arg": val,
+	}
+	var result Result
+	_, err := cl.Call("status", params, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := result.(*ResultStatus).Value
+	if got != val {
+		t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
+	}
+}
+
+func TestQuotedStringArg(t *testing.T) {
+	cl := rpcclient.NewClientURI(tcpAddr)
+	// should NOT be unquoted
+	val := "\"abc\""
+	params := map[string]interface{}{
+		"arg": val,
+	}
+	var result Result
+	_, err := cl.Call("status", params, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := result.(*ResultStatus).Value
+	if got != val {
+		t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
+	}
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -6,7 +6,7 @@ go build -o server main.go
 PID=$!
 sleep 2
 
-# simple JSONRPC request
+# simple request
 R1=`curl -s 'http://localhost:8008/hello_world?name="my_world"&num=5'`
 R2=`curl -s --data @data.json http://localhost:8008`
 if [[ "$R1" != "$R2" ]]; then
@@ -42,4 +42,16 @@ else
 	echo "Success"
 fi
 
-kill -9 $PID
+# request with string type when expecting number arg
+R1=`curl -s 'http://localhost:8008/hello_world?name="abcd"&num=0xabcd'`
+R2="{\"jsonrpc\":\"2.0\",\"id\":\"\",\"result\":null,\"error\":\"Error converting http params to args: Got a 'hex string' arg, but expected 'int'\"}"
+if [[ "$R1" != "$R2" ]]; then
+	echo "responses are not identical:"
+	echo "R1: $R1"
+	echo "R2: $R2"
+	exit 1
+else
+	echo "Success"
+fi
+
+kill -9 $PID || exit 0

--- a/test/test.sh
+++ b/test/test.sh
@@ -6,18 +6,37 @@ go build -o server main.go
 PID=$!
 sleep 2
 
-
+# simple JSONRPC request
 R1=`curl -s 'http://localhost:8008/hello_world?name="my_world"&num=5'`
-
-
 R2=`curl -s --data @data.json http://localhost:8008`
-
-kill -9 $PID
-
 if [[ "$R1" != "$R2" ]]; then
 	echo "responses are not identical:"
 	echo "R1: $R1"
 	echo "R2: $R2"
-	exit 1
+else
+	echo "Success"
 fi
-echo "Success"
+
+# request with 0x-prefixed hex string arg
+R1=`curl -s 'http://localhost:8008/hello_world?name=0x41424344&num=123'`
+R2='{"jsonrpc":"2.0","id":"","result":{"Result":"hi ABCD 123"},"error":""}'
+if [[ "$R1" != "$R2" ]]; then
+	echo "responses are not identical:"
+	echo "R1: $R1"
+	echo "R2: $R2"
+else
+	echo "Success"
+fi
+
+# request with unquoted string arg
+R1=`curl -s 'http://localhost:8008/hello_world?name=abcd&num=123'`
+R2="{\"jsonrpc\":\"2.0\",\"id\":\"\",\"result\":null,\"error\":\"Error converting http params to args: invalid character 'a' looking for beginning of value\"}"
+if [[ "$R1" != "$R2" ]]; then
+	echo "responses are not identical:"
+	echo "R1: $R1"
+	echo "R2: $R2"
+else
+	echo "Success"
+fi
+
+kill -9 $PID

--- a/test/test.sh
+++ b/test/test.sh
@@ -13,6 +13,7 @@ if [[ "$R1" != "$R2" ]]; then
 	echo "responses are not identical:"
 	echo "R1: $R1"
 	echo "R2: $R2"
+	exit 1
 else
 	echo "Success"
 fi
@@ -24,6 +25,7 @@ if [[ "$R1" != "$R2" ]]; then
 	echo "responses are not identical:"
 	echo "R1: $R1"
 	echo "R2: $R2"
+	exit 1
 else
 	echo "Success"
 fi
@@ -35,6 +37,7 @@ if [[ "$R1" != "$R2" ]]; then
 	echo "responses are not identical:"
 	echo "R1: $R1"
 	echo "R2: $R2"
+	exit 1
 else
 	echo "Success"
 fi


### PR DESCRIPTION
See https://github.com/tendermint/tendermint/issues/346

This PR changes the RPC server to treat quoted strings as normal strings (rather than as hex, which is what `go-wire` is currently doing for us) and also allows "0x"-prefixed hex strings.

`go-wire` turns byte arrays into quoted hex strings, so on the client we now transform these into "0x"-prefixed hex strings to make sure the RPC server interprets the value as hex.