### PR TITLE
support key-value params in JSONRPC

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+
+[*.sh]
+indent_style = tab

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:latest
+
+RUN mkdir -p /go/src/github.com/tendermint/go-rpc
+WORKDIR /go/src/github.com/tendermint/go-rpc
+
+COPY Makefile /go/src/github.com/tendermint/go-rpc/
+# COPY glide.yaml /go/src/github.com/tendermint/go-rpc/
+# COPY glide.lock /go/src/github.com/tendermint/go-rpc/
+
+COPY . /go/src/github.com/tendermint/go-rpc
+
+RUN make get_deps

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
-.PHONY: all test get_deps
+PACKAGES=$(shell go list ./...)
 
 all: test
 
-test: 
-	bash ./test/test.sh
+test:
+	@echo "--> Running go test --race"
+	@go test --race $(PACKAGES)
+	@echo "--> Running integration tests"
+	@bash ./test/integration_test.sh
 
 get_deps:
-	go get -t -u github.com/tendermint/go-rpc/...
+	@echo "--> Running go get"
+	@go get -v -d $(PACKAGES)
+
+.PHONY: all test get_deps

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PACKAGES=$(shell go list ./...)
 
-all: test
+all: get_deps test
 
 test:
 	@echo "--> Running go test --race"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES=$(shell go list ./...)
+PACKAGES=$(shell go list ./... | grep -v "test")
 
 all: get_deps test
 

--- a/README.md
+++ b/README.md
@@ -109,3 +109,18 @@ Each route is available as a GET request, as a JSONRPCv2 POST request, and via J
 
 * [Tendermint](https://github.com/tendermint/tendermint/blob/master/rpc/core/routes.go)
 * [Network Monitor](https://github.com/tendermint/netmon/blob/master/handlers/routes.go)
+
+## CHANGELOG
+
+### 0.7.0
+
+BREAKING CHANGES:
+
+- removed `Client` empty interface
+- `ClientJSONRPC#Call` `params` argument became a map
+
+IMPROVEMENTS:
+
+- added `HTTPClient` interface, which can be used for both `ClientURI`
+and `ClientJSONRPC`
+- all params are now optional (Golang's default will be used if some param is missing)

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ As a POST request, we use JSONRPC. For instance, the same request would have thi
 
 ```
 {
-	"jsonrpc":"2.0",
-	"id":"anything",
-	"method":"hello_world",
-	"params":["my_world", 5]
+  "jsonrpc": "2.0",
+  "id": "anything",
+  "method": "hello_world",
+  "params": {
+    "name": "my_world",
+    "num": 5
+  }
 }
 ```
-
-Note the `params` does not currently support key-value pairs (https://github.com/tendermint/go-rpc/issues/1), so order matters (you can get the order from making a 
-GET request to `/`)
 
 With the above saved in file `data.json`, we can make the request with
 
@@ -50,8 +50,8 @@ curl --data @data.json http://localhost:8008
 
 ## WebSocket (JSONRPC)
 
-All requests are exposed over websocket in the same form as the POST JSONRPC. 
-Websocket connections are available at their own endpoint, typically `/websocket`, 
+All requests are exposed over websocket in the same form as the POST JSONRPC.
+Websocket connections are available at their own endpoint, typically `/websocket`,
 though this is configurable when starting the server.
 
 # Server Definition
@@ -102,7 +102,7 @@ go func() {
 Note that unix sockets are supported as well (eg. `/path/to/socket` instead of `0.0.0.0:8008`)
 
 Now see all available endpoints by sending a GET request to `0.0.0.0:8008`.
-Each route is available as a GET request, as a JSONRPCv2 POST request, and via JSONRPCv2 over websockets
+Each route is available as a GET request, as a JSONRPCv2 POST request, and via JSONRPCv2 over websockets.
 
 
 # Examples

--- a/circle.yml
+++ b/circle.yml
@@ -11,12 +11,10 @@ checkout:
     - rm -rf $REPO
     - mkdir -p $HOME/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME
     - mv $HOME/$CIRCLE_PROJECT_REPONAME $REPO
-    # - git submodule sync
-    # - git submodule update --init # use submodules
 
 dependencies:
   override:
-    - "cd $REPO"
+    - "cd $REPO && make get_deps"
 
 test:
   override:

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/pkg/errors"
 	types "github.com/tendermint/go-rpc/types"
 	wire "github.com/tendermint/go-wire"
 )
@@ -143,16 +144,16 @@ func unmarshalResponseBytes(responseBytes []byte, result interface{}) (interface
 	response := &types.RPCResponse{}
 	err = json.Unmarshal(responseBytes, response)
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling rpc response: %v", err)
+		return nil, errors.Errorf("Error unmarshalling rpc response: %v", err)
 	}
 	errorStr := response.Error
 	if errorStr != "" {
-		return nil, fmt.Errorf("Response error: %v", errorStr)
+		return nil, errors.Errorf("Response error: %v", errorStr)
 	}
 	// unmarshal the RawMessage into the result
 	result = wire.ReadJSONPtr(result, *response.Result, &err)
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling rpc response result: %v", err)
+		return nil, errors.Errorf("Error unmarshalling rpc response result: %v", err)
 	}
 	return result, nil
 }

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -67,10 +67,6 @@ func NewClientJSONRPC(remote string) *ClientJSONRPC {
 }
 
 func (c *ClientJSONRPC) Call(method string, params map[string]interface{}, result interface{}) (interface{}, error) {
-	return c.call(method, params, result)
-}
-
-func (c *ClientJSONRPC) call(method string, params map[string]interface{}, result interface{}) (interface{}, error) {
 	// Make request and get responseBytes
 	request := types.RPCRequest{
 		JSONRPC: "2.0",
@@ -114,10 +110,6 @@ func NewClientURI(remote string) *ClientURI {
 }
 
 func (c *ClientURI) Call(method string, params map[string]interface{}, result interface{}) (interface{}, error) {
-	return c.call(method, params, result)
-}
-
-func (c *ClientURI) call(method string, params map[string]interface{}, result interface{}) (interface{}, error) {
 	values, err := argsToURLValues(params)
 	if err != nil {
 		return nil, err

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -17,7 +17,7 @@ import (
 
 // HTTPClient is a common interface for ClientJSONRPC and ClientURI.
 type HTTPClient interface {
-	Call(method string, params []interface{}, result interface{}) (interface{}, error)
+	Call(method string, params map[string]interface{}, result interface{}) (interface{}, error)
 }
 
 // TODO: Deprecate support for IP:PORT or /path/to/socket

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -11,8 +11,7 @@ import (
 	"reflect"
 	"strings"
 
-	// cmn "github.com/tendermint/go-common"
-	rpctypes "github.com/tendermint/go-rpc/types"
+	types "github.com/tendermint/go-rpc/types"
 	wire "github.com/tendermint/go-wire"
 )
 
@@ -28,7 +27,7 @@ func makeHTTPDialer(remoteAddr string) (string, func(string, string) (net.Conn, 
 	var protocol, address string
 	if len(parts) != 2 {
 		log.Warn("WARNING (go-rpc): Please use fully formed listening addresses, including the tcp:// or unix:// prefix")
-		protocol = rpctypes.SocketType(remoteAddr)
+		protocol = types.SocketType(remoteAddr)
 		address = remoteAddr
 	} else {
 		protocol, address = parts[0], parts[1]
@@ -73,7 +72,7 @@ func (c *ClientJSONRPC) Call(method string, params map[string]interface{}, resul
 
 func (c *ClientJSONRPC) call(method string, params map[string]interface{}, result interface{}) (interface{}, error) {
 	// Make request and get responseBytes
-	request := rpctypes.RPCRequest{
+	request := types.RPCRequest{
 		JSONRPC: "2.0",
 		Method:  method,
 		Params:  params,
@@ -144,7 +143,7 @@ func unmarshalResponseBytes(responseBytes []byte, result interface{}) (interface
 	// into the correct type
 	// log.Notice("response", "response", string(responseBytes))
 	var err error
-	response := &rpctypes.RPCResponse{}
+	response := &types.RPCResponse{}
 	err = json.Unmarshal(responseBytes, response)
 	if err != nil {
 		return nil, fmt.Errorf("Error unmarshalling rpc response: %v", err)

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -72,7 +72,9 @@ func (c *ClientJSONRPC) Call(method string, params map[string]interface{}, resul
 	// (handlers.go:176) on the server side
 	encodedParams := make(map[string]interface{})
 	for k, v := range params {
-		encodedParams[k] = json.RawMessage(wire.JSONBytes(v))
+		// log.Printf("%s: %v (%s)\n", k, v, string(wire.JSONBytes(v)))
+		bytes := json.RawMessage(wire.JSONBytes(v))
+		encodedParams[k] = &bytes
 	}
 	request := types.RPCRequest{
 		JSONRPC: "2.0",
@@ -84,6 +86,7 @@ func (c *ClientJSONRPC) Call(method string, params map[string]interface{}, resul
 	if err != nil {
 		return nil, err
 	}
+	// log.Info(string(requestBytes))
 	requestBuf := bytes.NewBuffer(requestBytes)
 	// log.Info(Fmt("RPC request to %v (%v): %v", c.remote, method, string(requestBytes)))
 	httpResponse, err := c.client.Post(c.address, "text/json", requestBuf)

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -67,11 +67,16 @@ func NewClientJSONRPC(remote string) *ClientJSONRPC {
 }
 
 func (c *ClientJSONRPC) Call(method string, params map[string]interface{}, result interface{}) (interface{}, error) {
-	// Make request and get responseBytes
+	// we need this step because we attempt to decode values using `go-wire`
+	// (handlers.go:176) on the server side
+	encodedParams := make(map[string]interface{})
+	for k, v := range params {
+		encodedParams[k] = json.RawMessage(wire.JSONBytes(v))
+	}
 	request := types.RPCRequest{
 		JSONRPC: "2.0",
 		Method:  method,
-		Params:  params,
+		Params:  encodedParams,
 		ID:      "",
 	}
 	requestBytes, err := json.Marshal(request)

--- a/client/ws_client.go
+++ b/client/ws_client.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	cmn "github.com/tendermint/go-common"
-	rpctypes "github.com/tendermint/go-rpc/types"
+	types "github.com/tendermint/go-rpc/types"
 )
 
 const (
@@ -96,7 +96,7 @@ func (wsc *WSClient) receiveEventsRoutine() {
 			wsc.Stop()
 			break
 		} else {
-			var response rpctypes.RPCResponse
+			var response types.RPCResponse
 			err := json.Unmarshal(data, &response)
 			if err != nil {
 				log.Info("WSClient failed to parse message", "error", err, "data", string(data))
@@ -118,7 +118,7 @@ func (wsc *WSClient) receiveEventsRoutine() {
 
 // subscribe to an event
 func (wsc *WSClient) Subscribe(eventid string) error {
-	err := wsc.WriteJSON(rpctypes.RPCRequest{
+	err := wsc.WriteJSON(types.RPCRequest{
 		JSONRPC: "2.0",
 		ID:      "",
 		Method:  "subscribe",
@@ -129,7 +129,7 @@ func (wsc *WSClient) Subscribe(eventid string) error {
 
 // unsubscribe from an event
 func (wsc *WSClient) Unsubscribe(eventid string) error {
-	err := wsc.WriteJSON(rpctypes.RPCRequest{
+	err := wsc.WriteJSON(types.RPCRequest{
 		JSONRPC: "2.0",
 		ID:      "",
 		Method:  "unsubscribe",

--- a/client/ws_client.go
+++ b/client/ws_client.go
@@ -2,12 +2,12 @@ package rpcclient
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
 	cmn "github.com/tendermint/go-common"
 	types "github.com/tendermint/go-rpc/types"
 )
@@ -104,7 +104,7 @@ func (wsc *WSClient) receiveEventsRoutine() {
 				continue
 			}
 			if response.Error != "" {
-				wsc.ErrorsCh <- fmt.Errorf(response.Error)
+				wsc.ErrorsCh <- errors.Errorf(response.Error)
 				continue
 			}
 			wsc.ResultsCh <- *response.Result

--- a/client/ws_client.go
+++ b/client/ws_client.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	. "github.com/tendermint/go-common"
-	"github.com/tendermint/go-rpc/types"
+	cmn "github.com/tendermint/go-common"
+	rpctypes "github.com/tendermint/go-rpc/types"
 )
 
 const (
@@ -19,7 +19,7 @@ const (
 )
 
 type WSClient struct {
-	BaseService
+	cmn.BaseService
 	Address  string // IP:PORT or /path/to/socket
 	Endpoint string // /websocket/url/endpoint
 	Dialer   func(string, string) (net.Conn, error)
@@ -39,7 +39,7 @@ func NewWSClient(remoteAddr, endpoint string) *WSClient {
 		ResultsCh: make(chan json.RawMessage, wsResultsChannelCapacity),
 		ErrorsCh:  make(chan error, wsErrorsChannelCapacity),
 	}
-	wsClient.BaseService = *NewBaseService(log, "WSClient", wsClient)
+	wsClient.BaseService = *cmn.NewBaseService(log, "WSClient", wsClient)
 	return wsClient
 }
 
@@ -122,7 +122,7 @@ func (wsc *WSClient) Subscribe(eventid string) error {
 		JSONRPC: "2.0",
 		ID:      "",
 		Method:  "subscribe",
-		Params:  []interface{}{eventid},
+		Params:  map[string]interface{}{"event": eventid},
 	})
 	return err
 }
@@ -133,7 +133,7 @@ func (wsc *WSClient) Unsubscribe(eventid string) error {
 		JSONRPC: "2.0",
 		ID:      "",
 		Method:  "unsubscribe",
-		Params:  []interface{}{eventid},
+		Params:  map[string]interface{}{"event": eventid},
 	})
 	return err
 }

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tendermint/go-rpc/client"
-	"github.com/tendermint/go-rpc/server"
-	"github.com/tendermint/go-rpc/types"
-	"github.com/tendermint/go-wire"
+	rpcclient "github.com/tendermint/go-rpc/client"
+	rpcserver "github.com/tendermint/go-rpc/server"
+	rpctypes "github.com/tendermint/go-rpc/types"
+	wire "github.com/tendermint/go-wire"
 )
 
 // Client and Server should work over tcp or unix sockets
@@ -88,7 +88,9 @@ func testURI(t *testing.T, cl *rpcclient.ClientURI) {
 
 func testJSONRPC(t *testing.T, cl *rpcclient.ClientJSONRPC) {
 	val := "acbd"
-	params := []interface{}{val}
+	params := map[string]interface{}{
+		"arg": val,
+	}
 	var result Result
 	_, err := cl.Call("status", params, &result)
 	if err != nil {
@@ -102,7 +104,9 @@ func testJSONRPC(t *testing.T, cl *rpcclient.ClientJSONRPC) {
 
 func testWS(t *testing.T, cl *rpcclient.WSClient) {
 	val := "acbd"
-	params := []interface{}{val}
+	params := map[string]interface{}{
+		"arg": val,
+	}
 	err := cl.WriteJSON(rpctypes.RPCRequest{
 		JSONRPC: "2.0",
 		ID:      "",

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"net/http"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -13,8 +14,10 @@ import (
 
 // Client and Server should work over tcp or unix sockets
 const (
-	tcpAddr  = "tcp://0.0.0.0:46657"
-	unixAddr = "unix:///tmp/go-rpc.sock" // NOTE: must remove file for test to run again
+	tcpAddr = "tcp://0.0.0.0:46657"
+
+	unixSocket = "/tmp/go-rpc.sock"
+	unixAddr   = "unix:///tmp/go-rpc.sock"
 
 	websocketEndpoint = "/websocket/endpoint"
 )
@@ -43,6 +46,12 @@ func StatusResult(v string) (Result, error) {
 
 // launch unix and tcp servers
 func init() {
+	cmd := exec.Command("rm", "-f", unixSocket)
+	err := cmd.Start()
+	if err != nil {
+		panic(err)
+	}
+	err = cmd.Wait()
 
 	mux := http.NewServeMux()
 	server.RegisterRPCFuncs(mux, Routes)

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -140,15 +140,19 @@ func testWS(t *testing.T, cl *client.WSClient) {
 		t.Fatal(err)
 	}
 
-	msg := <-cl.ResultsCh
-	result := new(Result)
-	wire.ReadJSONPtr(result, msg, &err)
-	if err != nil {
+	select {
+	case msg := <-cl.ResultsCh:
+		result := new(Result)
+		wire.ReadJSONPtr(result, msg, &err)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := (*result).(*ResultStatus).Value
+		if got != val {
+			t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
+		}
+	case err := <-cl.ErrorsCh:
 		t.Fatal(err)
-	}
-	got := (*result).(*ResultStatus).Value
-	if got != val {
-		t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
 	}
 }
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
 	cmn "github.com/tendermint/go-common"
 	events "github.com/tendermint/go-events"
 	types "github.com/tendermint/go-rpc/types"
@@ -272,7 +273,7 @@ func nonJsonToArg(ty reflect.Type, arg string) (reflect.Value, error, bool) {
 
 	if isHexString {
 		if !expectingString && !expectingByteSlice {
-			err := fmt.Errorf("Got a hex string arg, but expected '%s'",
+			err := errors.Errorf("Got a hex string arg, but expected '%s'",
 				ty.Kind().String())
 			return reflect.ValueOf(nil), err, false
 		}
@@ -567,7 +568,7 @@ func (wm *WebsocketManager) WebsocketHandler(w http.ResponseWriter, r *http.Requ
 func unreflectResult(returns []reflect.Value) (interface{}, error) {
 	errV := returns[1]
 	if errV.Interface() != nil {
-		return nil, fmt.Errorf("%v", errV.Interface())
+		return nil, errors.Errorf("%v", errV.Interface())
 	}
 	rv := returns[0]
 	// the result is a registered interface,

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -176,7 +176,7 @@ func indexOf(value string, values []string) int {
 
 // Same as above, but with the first param the websocket connection
 func jsonParamsToArgsWS(rpcFunc *RPCFunc, params map[string]interface{}, wsCtx types.WSRPCContext) ([]reflect.Value, error) {
-	values := make([]reflect.Value, len(rpcFunc.args))
+	values := make([]reflect.Value, len(rpcFunc.args)+1)
 	values[0] = reflect.ValueOf(wsCtx)
 
 	// fill each value with default
@@ -189,7 +189,7 @@ func jsonParamsToArgsWS(rpcFunc *RPCFunc, params map[string]interface{}, wsCtx t
 		if -1 == i {
 			return nil, fmt.Errorf("%s is not an argument (args: %v)", name, rpcFunc.argNames)
 		}
-		argType := rpcFunc.args[i+1]
+		argType := rpcFunc.args[i]
 		v, err := _jsonObjectToArg(argType, param)
 		if err != nil {
 			return nil, err

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -14,10 +13,10 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	. "github.com/tendermint/go-common"
-	"github.com/tendermint/go-events"
-	. "github.com/tendermint/go-rpc/types"
-	"github.com/tendermint/go-wire"
+	cmn "github.com/tendermint/go-common"
+	events "github.com/tendermint/go-events"
+	types "github.com/tendermint/go-rpc/types"
+	wire "github.com/tendermint/go-wire"
 )
 
 // Adds a route for each function in the funcMap, as well as general jsonrpc and websocket handlers for all functions.
@@ -105,75 +104,99 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc) http.HandlerFunc {
 			return
 		}
 
-		var request RPCRequest
+		var request types.RPCRequest
 		err := json.Unmarshal(b, &request)
 		if err != nil {
-			WriteRPCResponseHTTP(w, NewRPCResponse("", nil, fmt.Sprintf("Error unmarshalling request: %v", err.Error())))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse("", nil, fmt.Sprintf("Error unmarshalling request: %v", err.Error())))
 			return
 		}
 		if len(r.URL.Path) > 1 {
-			WriteRPCResponseHTTP(w, NewRPCResponse(request.ID, nil, fmt.Sprintf("Invalid JSONRPC endpoint %s", r.URL.Path)))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse(request.ID, nil, fmt.Sprintf("Invalid JSONRPC endpoint %s", r.URL.Path)))
 			return
 		}
 		rpcFunc := funcMap[request.Method]
 		if rpcFunc == nil {
-			WriteRPCResponseHTTP(w, NewRPCResponse(request.ID, nil, "RPC method unknown: "+request.Method))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse(request.ID, nil, "RPC method unknown: "+request.Method))
 			return
 		}
 		if rpcFunc.ws {
-			WriteRPCResponseHTTP(w, NewRPCResponse(request.ID, nil, "RPC method is only for websockets: "+request.Method))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse(request.ID, nil, "RPC method is only for websockets: "+request.Method))
 			return
 		}
 		args, err := jsonParamsToArgs(rpcFunc, request.Params)
 		if err != nil {
-			WriteRPCResponseHTTP(w, NewRPCResponse(request.ID, nil, fmt.Sprintf("Error converting json params to arguments: %v", err.Error())))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse(request.ID, nil, fmt.Sprintf("Error converting json params to arguments: %v", err.Error())))
 			return
 		}
 		returns := rpcFunc.f.Call(args)
 		log.Info("HTTPJSONRPC", "method", request.Method, "args", args, "returns", returns)
 		result, err := unreflectResult(returns)
 		if err != nil {
-			WriteRPCResponseHTTP(w, NewRPCResponse(request.ID, result, fmt.Sprintf("Error unreflecting result: %v", err.Error())))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse(request.ID, result, fmt.Sprintf("Error unreflecting result: %v", err.Error())))
 			return
 		}
-		WriteRPCResponseHTTP(w, NewRPCResponse(request.ID, result, ""))
+		WriteRPCResponseHTTP(w, types.NewRPCResponse(request.ID, result, ""))
 	}
 }
 
 // Convert a list of interfaces to properly typed values
-func jsonParamsToArgs(rpcFunc *RPCFunc, params []interface{}) ([]reflect.Value, error) {
+func jsonParamsToArgs(rpcFunc *RPCFunc, params map[string]interface{}) ([]reflect.Value, error) {
 	if len(rpcFunc.argNames) != len(params) {
-		return nil, errors.New(fmt.Sprintf("Expected %v parameters (%v), got %v (%v)",
-			len(rpcFunc.argNames), rpcFunc.argNames, len(params), params))
+		return nil, fmt.Errorf("Expected %v parameters (%v), got %v (%v)",
+			len(rpcFunc.argNames), rpcFunc.argNames, len(params), params)
 	}
+
 	values := make([]reflect.Value, len(params))
-	for i, p := range params {
+
+	for name, param := range params {
+		i := indexOf(name, rpcFunc.argNames)
+		if -1 == i {
+			return nil, fmt.Errorf("%s is not an argument (args: %v)", name, rpcFunc.argNames)
+		}
 		ty := rpcFunc.args[i]
-		v, err := _jsonObjectToArg(ty, p)
+		v, err := _jsonObjectToArg(ty, param)
 		if err != nil {
 			return nil, err
 		}
 		values[i] = v
 	}
+
 	return values, nil
 }
 
-// Same as above, but with the first param the websocket connection
-func jsonParamsToArgsWS(rpcFunc *RPCFunc, params []interface{}, wsCtx WSRPCContext) ([]reflect.Value, error) {
-	if len(rpcFunc.argNames) != len(params) {
-		return nil, errors.New(fmt.Sprintf("Expected %v parameters (%v), got %v (%v)",
-			len(rpcFunc.argNames)-1, rpcFunc.argNames[1:], len(params), params))
+// indexOf returns index of a string in a slice of strings, -1 if not found.
+func indexOf(value string, values []string) int {
+	for i, v := range values {
+		if v == value {
+			return i
+		}
 	}
+	return -1
+}
+
+// Same as above, but with the first param the websocket connection
+func jsonParamsToArgsWS(rpcFunc *RPCFunc, params map[string]interface{}, wsCtx types.WSRPCContext) ([]reflect.Value, error) {
+	if len(rpcFunc.argNames) != len(params) {
+		return nil, fmt.Errorf("Expected %v parameters (%v), got %v (%v)",
+			len(rpcFunc.argNames)-1, rpcFunc.argNames[1:], len(params), params)
+	}
+
 	values := make([]reflect.Value, len(params)+1)
 	values[0] = reflect.ValueOf(wsCtx)
-	for i, p := range params {
+
+	for name, param := range params {
+		i := indexOf(name, rpcFunc.argNames)
+		if -1 == i {
+			return nil, fmt.Errorf("%s is not an argument (args: %v)", name, rpcFunc.argNames)
+		}
 		ty := rpcFunc.args[i+1]
-		v, err := _jsonObjectToArg(ty, p)
+		v, err := _jsonObjectToArg(ty, param)
 		if err != nil {
 			return nil, err
 		}
 		values[i+1] = v
 	}
+
 	return values, nil
 }
 
@@ -197,7 +220,7 @@ func makeHTTPHandler(rpcFunc *RPCFunc) func(http.ResponseWriter, *http.Request) 
 	// Exception for websocket endpoints
 	if rpcFunc.ws {
 		return func(w http.ResponseWriter, r *http.Request) {
-			WriteRPCResponseHTTP(w, NewRPCResponse("", nil, "This RPC method is only for websockets"))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse("", nil, "This RPC method is only for websockets"))
 		}
 	}
 	// All other endpoints
@@ -205,17 +228,17 @@ func makeHTTPHandler(rpcFunc *RPCFunc) func(http.ResponseWriter, *http.Request) 
 		log.Debug("HTTP HANDLER", "req", r)
 		args, err := httpParamsToArgs(rpcFunc, r)
 		if err != nil {
-			WriteRPCResponseHTTP(w, NewRPCResponse("", nil, fmt.Sprintf("Error converting http params to args: %v", err.Error())))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse("", nil, fmt.Sprintf("Error converting http params to args: %v", err.Error())))
 			return
 		}
 		returns := rpcFunc.f.Call(args)
 		log.Info("HTTPRestRPC", "method", r.URL.Path, "args", args, "returns", returns)
 		result, err := unreflectResult(returns)
 		if err != nil {
-			WriteRPCResponseHTTP(w, NewRPCResponse("", nil, fmt.Sprintf("Error unreflecting result: %v", err.Error())))
+			WriteRPCResponseHTTP(w, types.NewRPCResponse("", nil, fmt.Sprintf("Error unreflecting result: %v", err.Error())))
 			return
 		}
-		WriteRPCResponseHTTP(w, NewRPCResponse("", result, ""))
+		WriteRPCResponseHTTP(w, types.NewRPCResponse("", result, ""))
 	}
 }
 
@@ -313,11 +336,11 @@ const (
 // contains listener id, underlying ws connection,
 // and the event switch for subscribing to events
 type wsConnection struct {
-	BaseService
+	cmn.BaseService
 
 	remoteAddr  string
 	baseConn    *websocket.Conn
-	writeChan   chan RPCResponse
+	writeChan   chan types.RPCResponse
 	readTimeout *time.Timer
 	pingTicker  *time.Ticker
 
@@ -330,11 +353,11 @@ func NewWSConnection(baseConn *websocket.Conn, funcMap map[string]*RPCFunc, evsw
 	wsc := &wsConnection{
 		remoteAddr: baseConn.RemoteAddr().String(),
 		baseConn:   baseConn,
-		writeChan:  make(chan RPCResponse, writeChanCapacity), // error when full.
+		writeChan:  make(chan types.RPCResponse, writeChanCapacity), // error when full.
 		funcMap:    funcMap,
 		evsw:       evsw,
 	}
-	wsc.BaseService = *NewBaseService(log, "wsConnection", wsc)
+	wsc.BaseService = *cmn.NewBaseService(log, "wsConnection", wsc)
 	return wsc
 }
 
@@ -399,7 +422,7 @@ func (wsc *wsConnection) GetEventSwitch() events.EventSwitch {
 // Implements WSRPCConnection
 // Blocking write to writeChan until service stops.
 // Goroutine-safe
-func (wsc *wsConnection) WriteRPCResponse(resp RPCResponse) {
+func (wsc *wsConnection) WriteRPCResponse(resp types.RPCResponse) {
 	select {
 	case <-wsc.Quit:
 		return
@@ -410,7 +433,7 @@ func (wsc *wsConnection) WriteRPCResponse(resp RPCResponse) {
 // Implements WSRPCConnection
 // Nonblocking write.
 // Goroutine-safe
-func (wsc *wsConnection) TryWriteRPCResponse(resp RPCResponse) bool {
+func (wsc *wsConnection) TryWriteRPCResponse(resp types.RPCResponse) bool {
 	select {
 	case <-wsc.Quit:
 		return false
@@ -444,11 +467,11 @@ func (wsc *wsConnection) readRoutine() {
 				wsc.Stop()
 				return
 			}
-			var request RPCRequest
+			var request types.RPCRequest
 			err = json.Unmarshal(in, &request)
 			if err != nil {
 				errStr := fmt.Sprintf("Error unmarshaling data: %s", err.Error())
-				wsc.WriteRPCResponse(NewRPCResponse(request.ID, nil, errStr))
+				wsc.WriteRPCResponse(types.NewRPCResponse(request.ID, nil, errStr))
 				continue
 			}
 
@@ -456,28 +479,28 @@ func (wsc *wsConnection) readRoutine() {
 
 			rpcFunc := wsc.funcMap[request.Method]
 			if rpcFunc == nil {
-				wsc.WriteRPCResponse(NewRPCResponse(request.ID, nil, "RPC method unknown: "+request.Method))
+				wsc.WriteRPCResponse(types.NewRPCResponse(request.ID, nil, "RPC method unknown: "+request.Method))
 				continue
 			}
 			var args []reflect.Value
 			if rpcFunc.ws {
-				wsCtx := WSRPCContext{Request: request, WSRPCConnection: wsc}
+				wsCtx := types.WSRPCContext{Request: request, WSRPCConnection: wsc}
 				args, err = jsonParamsToArgsWS(rpcFunc, request.Params, wsCtx)
 			} else {
 				args, err = jsonParamsToArgs(rpcFunc, request.Params)
 			}
 			if err != nil {
-				wsc.WriteRPCResponse(NewRPCResponse(request.ID, nil, err.Error()))
+				wsc.WriteRPCResponse(types.NewRPCResponse(request.ID, nil, err.Error()))
 				continue
 			}
 			returns := rpcFunc.f.Call(args)
 			log.Info("WSJSONRPC", "method", request.Method, "args", args, "returns", returns)
 			result, err := unreflectResult(returns)
 			if err != nil {
-				wsc.WriteRPCResponse(NewRPCResponse(request.ID, nil, err.Error()))
+				wsc.WriteRPCResponse(types.NewRPCResponse(request.ID, nil, err.Error()))
 				continue
 			} else {
-				wsc.WriteRPCResponse(NewRPCResponse(request.ID, result, ""))
+				wsc.WriteRPCResponse(types.NewRPCResponse(request.ID, result, ""))
 				continue
 			}
 

--- a/server/http_params.go
+++ b/server/http_params.go
@@ -2,10 +2,11 @@ package rpcserver
 
 import (
 	"encoding/hex"
-	"fmt"
 	"net/http"
 	"regexp"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -39,7 +40,7 @@ func GetParamInt64(r *http.Request, param string) (int64, error) {
 	s := GetParam(r, param)
 	i, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf(param, err.Error())
+		return 0, errors.Errorf(param, err.Error())
 	}
 	return i, nil
 }
@@ -48,7 +49,7 @@ func GetParamInt32(r *http.Request, param string) (int32, error) {
 	s := GetParam(r, param)
 	i, err := strconv.ParseInt(s, 10, 32)
 	if err != nil {
-		return 0, fmt.Errorf(param, err.Error())
+		return 0, errors.Errorf(param, err.Error())
 	}
 	return int32(i), nil
 }
@@ -57,7 +58,7 @@ func GetParamUint64(r *http.Request, param string) (uint64, error) {
 	s := GetParam(r, param)
 	i, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf(param, err.Error())
+		return 0, errors.Errorf(param, err.Error())
 	}
 	return i, nil
 }
@@ -66,7 +67,7 @@ func GetParamUint(r *http.Request, param string) (uint, error) {
 	s := GetParam(r, param)
 	i, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf(param, err.Error())
+		return 0, errors.Errorf(param, err.Error())
 	}
 	return uint(i), nil
 }
@@ -74,7 +75,7 @@ func GetParamUint(r *http.Request, param string) (uint, error) {
 func GetParamRegexp(r *http.Request, param string, re *regexp.Regexp) (string, error) {
 	s := GetParam(r, param)
 	if !re.MatchString(s) {
-		return "", fmt.Errorf(param, "Did not match regular expression %v", re.String())
+		return "", errors.Errorf(param, "Did not match regular expression %v", re.String())
 	}
 	return s, nil
 }
@@ -83,7 +84,7 @@ func GetParamFloat64(r *http.Request, param string) (float64, error) {
 	s := GetParam(r, param)
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return 0, fmt.Errorf(param, err.Error())
+		return 0, errors.Errorf(param, err.Error())
 	}
 	return f, nil
 }

--- a/server/http_server.go
+++ b/server/http_server.go
@@ -11,9 +11,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/tendermint/go-common"
-	. "github.com/tendermint/go-rpc/types"
-	//"github.com/tendermint/go-wire"
+	types "github.com/tendermint/go-rpc/types"
 )
 
 func StartHTTPServer(listenAddr string, handler http.Handler) (listener net.Listener, err error) {
@@ -24,14 +22,14 @@ func StartHTTPServer(listenAddr string, handler http.Handler) (listener net.List
 		log.Warn("WARNING (go-rpc): Please use fully formed listening addresses, including the tcp:// or unix:// prefix")
 		// we used to allow addrs without tcp/unix prefix by checking for a colon
 		// TODO: Deprecate
-		proto = SocketType(listenAddr)
+		proto = types.SocketType(listenAddr)
 		addr = listenAddr
 		// return nil, fmt.Errorf("Invalid listener address %s", lisenAddr)
 	} else {
 		proto, addr = parts[0], parts[1]
 	}
 
-	log.Notice(Fmt("Starting RPC HTTP server on %s socket %v", proto, addr))
+	log.Notice(fmt.Sprintf("Starting RPC HTTP server on %s socket %v", proto, addr))
 	listener, err = net.Listen(proto, addr)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to listen to %v: %v", listenAddr, err)
@@ -47,7 +45,7 @@ func StartHTTPServer(listenAddr string, handler http.Handler) (listener net.List
 	return listener, nil
 }
 
-func WriteRPCResponseHTTP(w http.ResponseWriter, res RPCResponse) {
+func WriteRPCResponseHTTP(w http.ResponseWriter, res types.RPCResponse) {
 	// jsonBytes := wire.JSONBytesPretty(res)
 	jsonBytes, err := json.Marshal(res)
 	if err != nil {
@@ -83,13 +81,13 @@ func RecoverAndLogHandler(handler http.Handler) http.Handler {
 			if e := recover(); e != nil {
 
 				// If RPCResponse
-				if res, ok := e.(RPCResponse); ok {
+				if res, ok := e.(types.RPCResponse); ok {
 					WriteRPCResponseHTTP(rww, res)
 				} else {
 					// For the rest,
 					log.Error("Panic in RPC HTTP handler", "error", e, "stack", string(debug.Stack()))
 					rww.WriteHeader(http.StatusInternalServerError)
-					WriteRPCResponseHTTP(rww, NewRPCResponse("", nil, Fmt("Internal Server Error: %v", e)))
+					WriteRPCResponseHTTP(rww, types.NewRPCResponse("", nil, fmt.Sprintf("Internal Server Error: %v", e)))
 				}
 			}
 

--- a/server/http_server.go
+++ b/server/http_server.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	types "github.com/tendermint/go-rpc/types"
 )
 
@@ -24,7 +25,7 @@ func StartHTTPServer(listenAddr string, handler http.Handler) (listener net.List
 		// TODO: Deprecate
 		proto = types.SocketType(listenAddr)
 		addr = listenAddr
-		// return nil, fmt.Errorf("Invalid listener address %s", lisenAddr)
+		// return nil, errors.Errorf("Invalid listener address %s", lisenAddr)
 	} else {
 		proto, addr = parts[0], parts[1]
 	}
@@ -32,7 +33,7 @@ func StartHTTPServer(listenAddr string, handler http.Handler) (listener net.List
 	log.Notice(fmt.Sprintf("Starting RPC HTTP server on %s socket %v", proto, addr))
 	listener, err = net.Listen(proto, addr)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to listen to %v: %v", listenAddr, err)
+		return nil, errors.Errorf("Failed to listen to %v: %v", listenAddr, err)
 	}
 
 	go func() {

--- a/test/data.json
+++ b/test/data.json
@@ -1,6 +1,9 @@
 {
-	"jsonrpc":"2.0",
-	"id":"",
-	"method":"hello_world",
-	"params":["my_world", 5]
+  "jsonrpc": "2.0",
+  "id": "",
+  "method": "hello_world",
+  "params": {
+    "name": "my_world",
+    "num": 5
+  }
 }

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -28,6 +28,7 @@ if [[ "$R1" != "$R2" ]]; then
 	echo "responses are not identical:"
 	echo "R1: $R1"
 	echo "R2: $R2"
+	echo "FAIL"
 	exit 1
 else
 	echo "OK"
@@ -40,18 +41,33 @@ if [[ "$R1" != "$R2" ]]; then
 	echo "responses are not identical:"
 	echo "R1: $R1"
 	echo "R2: $R2"
+	echo "FAIL"
 	exit 1
 else
 	echo "OK"
 fi
 
-# request with unquoted string arg
+echo "==> request with missing params"
+R1=$(curl -s 'http://localhost:8008/hello_world')
+R2='{"jsonrpc":"2.0","id":"","result":{"Result":"hi  0"},"error":""}'
+if [[ "$R1" != "$R2" ]]; then
+  echo "responses are not identical:"
+  echo "R1: $R1"
+  echo "R2: $R2"
+	echo "FAIL"
+  exit 1
+else
+  echo "OK"
+fi
+
+echo "==> request with unquoted string arg"
 R1=$(curl -s 'http://localhost:8008/hello_world?name=abcd&num=123')
 R2="{\"jsonrpc\":\"2.0\",\"id\":\"\",\"result\":null,\"error\":\"Error converting http params to args: invalid character 'a' looking for beginning of value\"}"
 if [[ "$R1" != "$R2" ]]; then
 	echo "responses are not identical:"
 	echo "R1: $R1"
 	echo "R2: $R2"
+	echo "FAIL"
 	exit 1
 else
 	echo "OK"
@@ -64,6 +80,7 @@ if [[ "$R1" != "$R2" ]]; then
 	echo "responses are not identical:"
 	echo "R1: $R1"
 	echo "R2: $R2"
+	echo "FAIL"
 	exit 1
 else
 	echo "OK"

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -15,7 +15,7 @@ go build -o rpcserver main.go
 echo "==> (Re)starting the server"
 PID=$(pgrep rpcserver || echo "")
 if [[ $PID != "" ]]; then
-  kill -9 "$PID"
+	kill -9 "$PID"
 fi
 ./rpcserver &
 PID=$!
@@ -51,13 +51,13 @@ echo "==> request with missing params"
 R1=$(curl -s 'http://localhost:8008/hello_world')
 R2='{"jsonrpc":"2.0","id":"","result":{"Result":"hi  0"},"error":""}'
 if [[ "$R1" != "$R2" ]]; then
-  echo "responses are not identical:"
-  echo "R1: $R1"
-  echo "R2: $R2"
+	echo "responses are not identical:"
+	echo "R1: $R1"
+	echo "R2: $R2"
 	echo "FAIL"
-  exit 1
+	exit 1
 else
-  echo "OK"
+	echo "OK"
 fi
 
 echo "==> request with unquoted string arg"

--- a/test/main.go
+++ b/test/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	. "github.com/tendermint/go-common"
+	cmn "github.com/tendermint/go-common"
 	rpcserver "github.com/tendermint/go-rpc/server"
 )
 
@@ -25,11 +25,11 @@ func main() {
 	rpcserver.RegisterRPCFuncs(mux, routes)
 	_, err := rpcserver.StartHTTPServer("0.0.0.0:8008", mux)
 	if err != nil {
-		Exit(err.Error())
+		cmn.Exit(err.Error())
 	}
 
 	// Wait forever
-	TrapSignal(func() {
+	cmn.TrapSignal(func() {
 	})
 
 }

--- a/test/main.go
+++ b/test/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
+	rpcserver "../server"
 	cmn "github.com/tendermint/go-common"
-	rpcserver "github.com/tendermint/go-rpc/server"
 )
 
 var routes = map[string]*rpcserver.RPCFunc{

--- a/test/main.go
+++ b/test/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	rpcserver "../server"
 	cmn "github.com/tendermint/go-common"
+	rpcserver "github.com/tendermint/go-rpc/server"
 )
 
 var routes = map[string]*rpcserver.RPCFunc{

--- a/types/types.go
+++ b/types/types.go
@@ -4,18 +4,18 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/tendermint/go-events"
-	"github.com/tendermint/go-wire"
+	events "github.com/tendermint/go-events"
+	wire "github.com/tendermint/go-wire"
 )
 
 type RPCRequest struct {
-	JSONRPC string        `json:"jsonrpc"`
-	ID      string        `json:"id"`
-	Method  string        `json:"method"`
-	Params  []interface{} `json:"params"`
+	JSONRPC string                 `json:"jsonrpc"`
+	ID      string                 `json:"id"`
+	Method  string                 `json:"method"`
+	Params  map[string]interface{} `json:"params"`
 }
 
-func NewRPCRequest(id string, method string, params []interface{}) RPCRequest {
+func NewRPCRequest(id string, method string, params map[string]interface{}) RPCRequest {
 	return RPCRequest{
 		JSONRPC: "2.0",
 		ID:      id,


### PR DESCRIPTION
Refs #1, #8, #7 

- remove Client interface (reason: empty)
- introduce HTTPClient interface, which can be used for both ClientURI
  and ClientJSONRPC clients (so our users don't have to create their own) (Refs #8)
- rename integration tests script to `integration_test.sh`
- do not update deps on `get_deps`

Upd.

- use golang default if an arg is missing