### PR TITLE
WSClient failing to echo bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ test:
 get_deps:
 	@echo "--> Running go get"
 	@go get -v -d $(PACKAGES)
+	@go list -f '{{join .TestImports "\n"}}' ./... | \
+		grep -v /vendor/ | sort | uniq | \
+		xargs go get -v -d
 
 .PHONY: all test get_deps

--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ IMPROVEMENTS:
 - added `HTTPClient` interface, which can be used for both `ClientURI`
 and `ClientJSONRPC`
 - all params are now optional (Golang's default will be used if some param is missing)
+- added `Call` method to `WSClient` (see method's doc for details)

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -72,7 +72,6 @@ func (c *JSONRPCClient) Call(method string, params map[string]interface{}, resul
 	// (handlers.go:176) on the server side
 	encodedParams := make(map[string]interface{})
 	for k, v := range params {
-		// log.Printf("%s: %v (%s)\n", k, v, string(wire.JSONBytes(v)))
 		bytes := json.RawMessage(wire.JSONBytes(v))
 		encodedParams[k] = &bytes
 	}

--- a/client/ws_client.go
+++ b/client/ws_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	cmn "github.com/tendermint/go-common"
 	types "github.com/tendermint/go-rpc/types"
+	wire "github.com/tendermint/go-wire"
 )
 
 const (
@@ -116,7 +117,8 @@ func (wsc *WSClient) receiveEventsRoutine() {
 	close(wsc.ErrorsCh)
 }
 
-// subscribe to an event
+// Subscribe to an event. Note the server must have a "subscribe" route
+// defined.
 func (wsc *WSClient) Subscribe(eventid string) error {
 	err := wsc.WriteJSON(types.RPCRequest{
 		JSONRPC: "2.0",
@@ -127,13 +129,33 @@ func (wsc *WSClient) Subscribe(eventid string) error {
 	return err
 }
 
-// unsubscribe from an event
+// Unsubscribe from an event. Note the server must have a "unsubscribe" route
+// defined.
 func (wsc *WSClient) Unsubscribe(eventid string) error {
 	err := wsc.WriteJSON(types.RPCRequest{
 		JSONRPC: "2.0",
 		ID:      "",
 		Method:  "unsubscribe",
 		Params:  map[string]interface{}{"event": eventid},
+	})
+	return err
+}
+
+// Call asynchronously calls a given method by sending an RPCRequest to the
+// server. Results will be available on ResultsCh, errors, if any, on ErrorsCh.
+func (wsc *WSClient) Call(method string, params map[string]interface{}) error {
+	// we need this step because we attempt to decode values using `go-wire`
+	// (handlers.go:470) on the server side
+	encodedParams := make(map[string]interface{})
+	for k, v := range params {
+		bytes := json.RawMessage(wire.JSONBytes(v))
+		encodedParams[k] = &bytes
+	}
+	err := wsc.WriteJSON(types.RPCRequest{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  encodedParams,
+		ID:      "",
 	})
 	return err
 }

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	client "github.com/tendermint/go-rpc/client"
 	server "github.com/tendermint/go-rpc/server"
 	types "github.com/tendermint/go-rpc/types"
@@ -105,13 +107,9 @@ func testURI(t *testing.T, cl *client.URIClient) {
 	}
 	var result Result
 	_, err := cl.Call("status", params, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	got := result.(*ResultStatus).Value
-	if got != val {
-		t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
-	}
+	assert.Equal(t, got, val)
 }
 
 func testJSONRPC(t *testing.T, cl *client.JSONRPCClient) {
@@ -121,13 +119,9 @@ func testJSONRPC(t *testing.T, cl *client.JSONRPCClient) {
 	}
 	var result Result
 	_, err := cl.Call("status", params, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	got := result.(*ResultStatus).Value
-	if got != val {
-		t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
-	}
+	assert.Equal(t, got, val)
 }
 
 func testWS(t *testing.T, cl *client.WSClient) {
@@ -141,21 +135,15 @@ func testWS(t *testing.T, cl *client.WSClient) {
 		Method:  "status",
 		Params:  params,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
 	select {
 	case msg := <-cl.ResultsCh:
 		result := new(Result)
 		wire.ReadJSONPtr(result, msg, &err)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 		got := (*result).(*ResultStatus).Value
-		if got != val {
-			t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
-		}
+		assert.Equal(t, got, val)
 	case err := <-cl.ErrorsCh:
 		t.Fatal(err)
 	}
@@ -186,18 +174,14 @@ func TestJSONRPC_UNIX(t *testing.T) {
 func TestWS_TCP(t *testing.T) {
 	cl := client.NewWSClient(tcpAddr, websocketEndpoint)
 	_, err := cl.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	testWS(t, cl)
 }
 
 func TestWS_UNIX(t *testing.T) {
 	cl := client.NewWSClient(unixAddr, websocketEndpoint)
 	_, err := cl.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	testWS(t, cl)
 }
 
@@ -210,13 +194,9 @@ func TestHexStringArg(t *testing.T) {
 	}
 	var result Result
 	_, err := cl.Call("status", params, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	got := result.(*ResultStatus).Value
-	if got != val {
-		t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
-	}
+	assert.Equal(t, got, val)
 }
 
 func TestQuotedStringArg(t *testing.T) {
@@ -228,22 +208,16 @@ func TestQuotedStringArg(t *testing.T) {
 	}
 	var result Result
 	_, err := cl.Call("status", params, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	got := result.(*ResultStatus).Value
-	if got != val {
-		t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
-	}
+	assert.Equal(t, got, val)
 }
 
 func randBytes(t *testing.T) []byte {
 	n := rand.Intn(10) + 2
 	buf := make([]byte, n)
 	_, err := crand.Read(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	return bytes.Replace(buf, []byte("="), []byte{100}, -1)
 }
 
@@ -256,21 +230,15 @@ func TestByteSliceViaJSONRPC(t *testing.T) {
 	}
 	var result Result
 	_, err := cl.Call("bytes", params, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	got := result.(*ResultBytes).Value
-	if bytes.Compare(got, val) != 0 {
-		t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
-	}
+	assert.Equal(t, got, val)
 }
 
 func TestWSNewWSRPCFunc(t *testing.T) {
 	cl := client.NewWSClient(unixAddr, websocketEndpoint)
 	_, err := cl.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	defer cl.Stop()
 
 	val := "acbd"
@@ -283,21 +251,15 @@ func TestWSNewWSRPCFunc(t *testing.T) {
 		Method:  "status_ws",
 		Params:  params,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
 	select {
 	case msg := <-cl.ResultsCh:
 		result := new(Result)
 		wire.ReadJSONPtr(result, msg, &err)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 		got := (*result).(*ResultStatus).Value
-		if got != val {
-			t.Fatalf("Got: %v   ....   Expected: %v \n", got, val)
-		}
+		assert.Equal(t, got, val)
 	case err := <-cl.ErrorsCh:
 		t.Fatal(err)
 	}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -71,7 +71,9 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = cmd.Wait()
+	if err = cmd.Wait(); err != nil {
+		panic(err)
+	}
 
 	mux := http.NewServeMux()
 	server.RegisterRPCFuncs(mux, Routes)

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -137,12 +137,7 @@ func echoViaWS(cl *client.WSClient, val string) (string, error) {
 	params := map[string]interface{}{
 		"arg": val,
 	}
-	err := cl.WriteJSON(types.RPCRequest{
-		JSONRPC: "2.0",
-		ID:      "",
-		Method:  "echo",
-		Params:  params,
-	})
+	err := cl.Call("echo", params)
 	if err != nil {
 		return "", err
 	}
@@ -164,12 +159,7 @@ func echoBytesViaWS(cl *client.WSClient, bytes []byte) ([]byte, error) {
 	params := map[string]interface{}{
 		"arg": bytes,
 	}
-	err := cl.WriteJSON(types.RPCRequest{
-		JSONRPC: "2.0",
-		ID:      "",
-		Method:  "echo_bytes",
-		Params:  params,
-	})
+	err := cl.Call("echo_bytes", params)
 	if err != nil {
 		return []byte{}, err
 	}


### PR DESCRIPTION
with

```
Expected nil, but got: encoding/hex: invalid byte: U+0078 'x'
```
(Test case https://github.com/tendermint/go-rpc/pull/11/commits/3233c9c003b8ed81ce2e9d18d39fdb5164d2d62a#diff-90ad426c7ba2dfb36ecebd8b350a50b7R163)

URIClient and JSONRPCClient both handle this case. Q: should WSClient also handle this encoding problem as well?